### PR TITLE
Supporting undefined expression in debug console

### DIFF
--- a/Assets/Code/NonebNi/EditorConsole/Expressions/UndefinedExpression.cs
+++ b/Assets/Code/NonebNi/EditorConsole/Expressions/UndefinedExpression.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace NonebNi.EditorConsole.Expressions
+{
+    public class UndefinedExpression : Expression
+    {
+        public UndefinedExpression(string stringRepresentation) : base(stringRepresentation) { }
+
+        public override Type ConvertableType =>
+            typeof(UndefinedType); //only convertable to UndefinedType - meaning any input with an unknown expression won't match any available command
+
+        public override object Value => new UndefinedType();
+
+        private class UndefinedType { }
+    }
+}

--- a/Assets/Code/NonebNi/EditorConsole/Expressions/UndefinedExpression.cs.meta
+++ b/Assets/Code/NonebNi/EditorConsole/Expressions/UndefinedExpression.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 16242995ec414a70ac4f56bf35dc1d60
+timeCreated: 1672601084

--- a/Assets/Code/NonebNi/EditorConsole/TextLexer.cs
+++ b/Assets/Code/NonebNi/EditorConsole/TextLexer.cs
@@ -37,6 +37,13 @@ namespace NonebNi.EditorConsole
 
                     yield return new IntParameter(int.Parse(intMatch.Value));
                 }
+                else
+                {
+                    //can't match anything - it's an undefined expression
+                    yield return new UndefinedExpression(input);
+
+                    input = string.Empty;
+                }
 
                 input = input.TrimStart();
             } while (input.Any());


### PR DESCRIPTION
When undefined command is entered - error message is printed instead of freezing the editor